### PR TITLE
Fix event requirement wording

### DIFF
--- a/main/management/commands/seed_events.py
+++ b/main/management/commands/seed_events.py
@@ -43,9 +43,9 @@ class Command(BaseCommand):
             image_temp.write(response.content)
             image_temp.flush()
 
-            # Random payed/free
-            requirement = random.choice(["payed", "free"])
-            price = random.randint(10000, 100000) if requirement == "payed" else None
+            # Random paid/free
+            requirement = random.choice(["paid", "free"])
+            price = random.randint(10000, 100000) if requirement == "paid" else None
 
             event = Event(
                 name=fake.sentence(nb_words=3),

--- a/main/migrations/0009_rename_time_event_start_time_remove_event_location_and_more.py
+++ b/main/migrations/0009_rename_time_event_start_time_remove_event_location_and_more.py
@@ -41,7 +41,7 @@ class Migration(migrations.Migration):
             model_name="event",
             name="requirements",
             field=models.CharField(
-                choices=[("FREE", "Bepul"), ("PAYED", "Pullik")],
+                choices=[("FREE", "Bepul"), ("PAID", "Pullik")],
                 default=1,
                 max_length=10,
             ),

--- a/main/models.py
+++ b/main/models.py
@@ -174,7 +174,7 @@ class Branch(models.Model):
 class Event(models.Model):
     REQUIREMENT_CHOICES = [
         ("FREE", "Bepul"),
-        ("PAYED", "Pullik"),
+        ("PAID", "Pullik"),
     ]
 
     name = models.CharField(max_length=255)


### PR DESCRIPTION
## Summary
- rename PAYED to PAID in Event model choices
- use PAID in migration for new databases
- generate `paid` events in seed command

## Testing
- `pytest -q` *(fails: OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_684ffbea253083259b244aa687ad966d