### PR TITLE
Fix quiz questions property naming

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -339,8 +339,9 @@ class Quiz(models.Model):
         return f"{self.name} (Unit {unit_num})"
 
     @property
-    def questions(self):
-        return self.questions.all()  
+    def question_list(self):
+        """Return all questions related to this quiz."""
+        return self.questions.all()
 
 
 def get_last_quiz():


### PR DESCRIPTION
## Summary
- rename `questions` property on `Quiz` model to `question_list`
- update property to use the related manager

## Testing
- `flake8`
- `pytest -q` *(fails: OperationalError connecting to PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_684ffdb1c8e48325b846f21d4d007a1b